### PR TITLE
Split JSON into several lines: By RFC 821 no line can be longer than 1,0...

### DIFF
--- a/lib/send_grid/api_header.rb
+++ b/lib/send_grid/api_header.rb
@@ -27,7 +27,7 @@ class SendGridSmtpApi::ApiHeader
   end
 
   def to_json
-    @data.to_json
+    JSON.generate(@data, {:indent => "", :space => "\n", :space_before => "\n", :object_nl => "\n", :array_nl => "\n"})
   end
 
   def standard_smtp(enabled = false)


### PR DESCRIPTION
According with section Requirements and Limitations from http://sendgrid.com/docs/API_Reference/SMTP_API/ the JSON need to be splitted into lines under 1000 characters.  
