### PR TITLE
CS-3342 [Action May Be Required] Twilio SendGrid

### DIFF
--- a/lib/send_grid.rb
+++ b/lib/send_grid.rb
@@ -23,7 +23,7 @@ module SendGridSmtpApi
     end
 
     def open_tracking(enabled = true)
-      add_filter_setting(:opentrack, :enabled, enabled ? 1 : 0) unless enabled.nil?
+      add_filter_setting(:opentrack, :enable, enabled ? 1 : 0) unless enabled.nil?
     end
   end
 end

--- a/lib/send_grid/version.rb
+++ b/lib/send_grid/version.rb
@@ -1,3 +1,3 @@
 module SendGridSmtpApi
-  VERSION = "1.0.0"
+  VERSION = "1.0.1"
 end

--- a/spec/mailer_spec.rb
+++ b/spec/mailer_spec.rb
@@ -16,12 +16,12 @@ describe Mailer do
   describe '#open_tracking' do
     it 'set correct open tracking enabled X-SMTAPI header' do
       Mailer.email_open_tracking.deliver.header.to_s.gsub(" ", "").
-        should include('{"filters":{"opentrack":{"settings":{"enabled":1}}')
+        should include('{"filters":{"opentrack":{"settings":{"enable":1}}')
     end
 
     it 'set correct open tracking disabled X-SMTAPI header' do
       Mailer.email_open_tracking(false).deliver.header.to_s.gsub(" ", "").
-        should include('"filters":{"opentrack":{"settings":{"enabled":0}}')
+        should include('"filters":{"opentrack":{"settings":{"enable":0}}')
     end
 
     it 'set correct open tracking nil X-SMTAPI header' do


### PR DESCRIPTION
Description
-----------

> The  word “enabled” (instead of “enable”) will no longer be a recognized parameter for the Mail Send API. The “enable” parameter is required, and if the parameter is omitted, settings will not be applied. Please use “enable” to ensure the desired behavior. 

Checklist
-----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] I have added appropriate tests if this PR fixes a bug or adds a feature.
- [ ] All [status checks](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/about-status-checks) (tests, linting, etc...) are passing.
