### PR TITLE
Support sendgrid ip pool feature in X-SMTPAPI Header

### DIFF
--- a/README.rdoc
+++ b/README.rdoc
@@ -71,6 +71,20 @@ Mailer class definition:
           end
         end
 
+=== Setting ip pool
+
+    Mailer class definition:
+
+        class Mailer < ActionMailer::Base
+          default :from => 'no-reply@example.com',
+                  :subject => 'An email sent via SendGridSmtpApi with substitutions'
+
+          def email_with_ip_pool
+            ip_pool 'IPPoolName'
+            mail :to => 'email1@email.com'
+          end
+        end
+
 == Apps (formerly called Filters)
 
 Apps can be applied to any of your email messages and can be configured through SendGridSmtpApi gem.

--- a/lib/send_grid.rb
+++ b/lib/send_grid.rb
@@ -6,7 +6,7 @@ module SendGridSmtpApi
   def self.included(base)
     base.class_eval do
       prepend InstanceMethods
-      delegate :substitute, :uniq_args, :category, :add_filter_setting, :standard_smtp, :to => :sendgrid_header
+      delegate :substitute, :uniq_args, :category, :add_filter_setting, :ip_pool, :standard_smtp, :to => :sendgrid_header
       alias_method :sendgrid_header, :send_grid_header
     end
   end

--- a/lib/send_grid/api_header.rb
+++ b/lib/send_grid/api_header.rb
@@ -26,6 +26,10 @@ class SendGridSmtpApi::ApiHeader
     @data[:filters][fltr][:settings][setting] = val
   end
 
+  def ip_pool(pool_name)
+    @data[:ip_pool] = pool_name
+  end
+
   def to_json
     JSON.generate(@data, {:indent => " ", :space => "", :space_before => "", :object_nl => "", :array_nl => ""})
   end
@@ -33,5 +37,4 @@ class SendGridSmtpApi::ApiHeader
   def standard_smtp(enabled = false)
     @standard_smtp = enabled
   end
-
 end

--- a/spec/api_header_spec.rb
+++ b/spec/api_header_spec.rb
@@ -36,5 +36,10 @@ describe SendGridSmtpApi::ApiHeader do
       header.add_filter_setting :filter1, :setting1, 'val1'
       header.to_json.should eql '{ "filters":{  "filter1":{   "settings":{    "setting1":"val1"   }  } }}'
     end
+
+    it "contains ip_pool" do
+      header.ip_pool 'pool_name'
+      header.to_json.should eql '{ "ip_pool":"pool_name"}'
+    end
   end
 end


### PR DESCRIPTION
Description
-----------
Resolves #8 

Sendgrid supports the inclusion of `ip_pool` in the X-SMPTAPI header to determine the ip_pool to be used during delivery. This PR adds support for this feature.

Checklist
-----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have added appropriate tests if this PR fixes a bug or adds a feature.
- [x] All [status checks](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/about-status-checks) (tests, linting, etc...) are passing.
